### PR TITLE
Add missing size method for PCGALowRankMatrix

### DIFF
--- a/src/lowrank.jl
+++ b/src/lowrank.jl
@@ -51,6 +51,11 @@ function size(A::LowRankCovMatrix, i::Int)
 	end
 end
 
+function size(A::PCGALowRankMatrix)
+	s = length(A.etas[1]) + 1
+	return (s, s)
+end
+
 function size(A::PCGALowRankMatrix, i::Int)
 	if i == 1 || i == 2
 		return length(A.etas[1]) + 1#the +1 is for HX

--- a/test/testrpcga.jl
+++ b/test/testrpcga.jl
@@ -2,6 +2,14 @@ import GeostatInversion
 import RobustPmap
 import Base.Test
 
+@stderrcapture function pcgalowranksize(numetas=10, numobs=20)
+	etas = [rand(numobs) for i = 1 : numetas]
+	HX = rand(10)
+	R = spzeros(10, 10)
+	A = GeostatInversion.PCGALowRankMatrix(etas, HX, R)
+	@Base.Test.test size(A) == (size(A, 1), size(A, 2))
+end
+
 @stderrcapture function simplepcgalowranktest(numetas=10, numobs=20)
 	#[(HQH + R) HX; transpose(HX) zeros(p, p)]
 	noiselevels = [1e16, 0.]#none, nuge
@@ -133,6 +141,7 @@ end
 
 @Base.Test.testset "RPSGA" begin
 	@everywhere srand(2017)
+	pcgalowranksize()
 	simplepcgalowranktest()
 	simplelowrankcovtest()
 	lowrankcovconsistencytest()


### PR DESCRIPTION
IterativeSolvers.jl now uses `max(size(A))` in least-square solvers to determine the maximum number of iterations. This method is missing for the PCGALowRankMatrix of GeostatInversion.jl